### PR TITLE
New targets to list fix

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ function App() {
 
   const match = useRouteMatch('/hylyt/:id');
   const target = match
-    ? targets.find((t) => t.properties.id === Number(match.params.id))
+    ? targets.find((t) => t.properties.id === match.params.id)
     : null;
 
   return (

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -8,8 +8,8 @@ function Navigation() {
       <Navbar.Toggle aria-controls="basic-navbar-nav" />
       <Navbar.Collapse id="basic-navbar-nav">
         <Nav className="mr-auto">
-          <LinkContainer to="/hylyt">
-            <Nav.Link>Sukellusilmoitus</Nav.Link>
+          <LinkContainer to="/">
+            <Nav.Link>Etusivu</Nav.Link>
           </LinkContainer>
           <LinkContainer to="/hylyt">
             <Nav.Link>Hylyt</Nav.Link>

--- a/src/components/TargetPage/TargetLocationMap.jsx
+++ b/src/components/TargetPage/TargetLocationMap.jsx
@@ -23,7 +23,7 @@ function TargetLocationMap({ target }) {
         <LayersControl.Overlay name="Merimerkit">
           <TileLayer
             attribution='&copy; <a href="https://openseamap.org/index.php?id=imprint&L=1">OpenSeaMap</a> contributors'
-            url="http://tiles.openseamap.org/seamark/{z}/{x}/{y}.png"
+            url="https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png"
           />
         </LayersControl.Overlay>
         <Marker position={coordinates}>

--- a/src/components/TargetsList.jsx
+++ b/src/components/TargetsList.jsx
@@ -9,7 +9,7 @@ function TargetsList(props) {
   async function getTargetData() {
     const data = await targetService.getAllTargets();
     data.features.sort((a, b) => (a.properties.name > b.properties.name ? 1 : -1));
-    setTargets(data);
+    setTargets(data.features);
   }
 
   useEffect(() => {
@@ -37,7 +37,7 @@ function TargetsList(props) {
               </tr>
             </thead>
             <tbody>
-              {targets.features.map((target) => (
+              {targets.map((target) => (
                 <tr
                   key={target.properties.id}
                   onClick={() => onRowClick(target.properties.id)}

--- a/src/services/targets.js
+++ b/src/services/targets.js
@@ -4,7 +4,7 @@ import REACT_APP_SERVER_URL from '../util/config';
 const baseUrl = REACT_APP_SERVER_URL;
 
 const getAllTargets = () => {
-  const request = axios.get(`${baseUrl}/api/data`);
+  const request = axios.get(`${baseUrl}/api/targets`);
   return request.then((response) => response.data);
 };
 


### PR DESCRIPTION

App.jsx:ssä oleva targets-lista tulee nyt tietokannasta eikä targetdata.json -tiedostosta, joten uudet hylyt on siinä mukana ja niidenkin lisätietosivulle pääsee. Sama hylkylistasivulla. Lisäksi navipalkin päivitys "Sukellusilmoitus" -> "Etusivu" 

Tarvii backin PR:n 21:n toimiakseen.

Luonnoksena niin kauan kunnes hylyn tallennus -bugi on korjattu että voi testata.

(Yritin myös saada hylkylista-komponentin käyttämään App.jsx-komponentin targets-listaa suoraan sen sijaan että hylkylista-komponentti hakee ne itse uudelleen. Propsien siirto ja listan päivitys ei onnistunut. Ehkä joku muu osaa?)
