### PR TITLE
target notification fixes

### DIFF
--- a/cypress/integration/newtarget_page_spec.js
+++ b/cypress/integration/newtarget_page_spec.js
@@ -25,6 +25,7 @@ describe('Test submit', () => {
   it('user can submit', () => {
     cy.visit("/uusi");
     cy.get('[id=newname]').type('Test Tester');
+    cy.get('[id=newdivername]').type('Test Tester');
     cy.get('[id=newemail]').type('tester@test.com');
     cy.get('[id=newphone]').type('0415063434');
     cy.get('[id=newdescription]').type('newdescription');
@@ -43,6 +44,7 @@ describe('Test email and phone fields', () => {
   it('user has to fill email or phone', () => {
     cy.visit("/uusi");
     cy.get('[id=newname]').type('Test Tester');
+    cy.get('[id=newdivername]').type('Test Tester');
     cy.get('[id=newdescription]').type('newdescription');
     cy.get('[id=newlocationname]').type('newlocationname');
     cy.get('[id=newx]').type('25.34234323');

--- a/src/components/NewTargetForm.jsx
+++ b/src/components/NewTargetForm.jsx
@@ -31,9 +31,24 @@ function NewTargetForm(props) {
           <Form.Label>Kohteen nimi:</Form.Label>
           <Form.Control
             type="text"
+            name="targetname"
+            data-testid="testtargetname"
+            id="newname"
+            onChange={handleChange}
+            isInvalid={!!errors.targetname}
+          />
+          <Form.Control.Feedback type="invalid">
+            { errors.targetname }
+          </Form.Control.Feedback>
+        </Form.Group>
+        <br />
+        <Form.Group>
+          <Form.Label>Ilmoittajan nimi:</Form.Label>
+          <Form.Control
+            type="text"
             name="divername"
             data-testid="testdivername"
-            id="newname"
+            id="newdivername"
             onChange={handleChange}
             isInvalid={!!errors.divername}
           />

--- a/src/components/NewTargetForm.test.jsx
+++ b/src/components/NewTargetForm.test.jsx
@@ -6,7 +6,7 @@ import { wait } from '@testing-library/user-event/dist/utils';
 import NewTargetForm from './NewTargetForm';
 
 const postTarget = jest.fn();
-let form; let input; let input2; let input3; let input4; let input5; let input6; let input7; let input8; let input9; let
+let form; let input; let input1; let input2; let input3; let input4; let input5; let input6; let input7; let input8; let input9; let
   input10;
 
 describe('new target tests', () => {
@@ -17,6 +17,7 @@ describe('new target tests', () => {
       />,
     );
     form = component.getByTestId('testform');
+    input1 = component.getByTestId('testtargetname');
     input = component.getByTestId('testdivername');
     input2 = component.getByTestId('testphone');
     input3 = component.getByTestId('testemail');
@@ -39,6 +40,9 @@ describe('new target tests', () => {
   test('typo form does not get submitted', async () => {
     fireEvent.change(input, {
       target: { value: 's' },
+    });
+    fireEvent.change(input1, {
+      target: { value: 'h' },
     });
     fireEvent.change(input2, {
       target: { value: '0' },
@@ -90,6 +94,9 @@ describe('new target tests', () => {
   });
 
   test('submit works with all accurate inputs', async () => {
+    fireEvent.change(input1, {
+      target: { value: 'Hylyn Nimi' },
+    });
     fireEvent.change(input, {
       target: { value: 'Sukeltajan Nimi' },
     });
@@ -126,7 +133,8 @@ describe('new target tests', () => {
       expect(postTarget).toHaveBeenCalledTimes(1);
 
       expect(postTarget.mock.calls).toHaveLength(1);
-      expect(postTarget.mock.calls[0][0].name).toBe('Sukeltajan Nimi');
+      expect(postTarget.mock.calls[0][0].targetname).toBe('Hylyn Nimi');
+      expect(postTarget.mock.calls[0][0].divername).toBe('Sukeltajan Nimi');
       expect(postTarget.mock.calls[0][0].phone).toBe('0415064545');
       expect(postTarget.mock.calls[0][0].email).toBe('seppo@gmail.com');
       expect(postTarget.mock.calls[0][0].type).toBe('hylky');

--- a/src/hooks/useNewTargetForm.jsx
+++ b/src/hooks/useNewTargetForm.jsx
@@ -15,7 +15,8 @@ const useForm = (postTarget) => {
     const targetID = await targets.generateUniqueID();
     postTarget({
       id: targetID,
-      name: requiredValues.divername,
+      targetname: requiredValues.targetname,
+      divername: requiredValues.divername,
       town: requiredValues.locationname || '',
       type: requiredValues.targetdescription,
       x_coordinate: requiredValues.xcoordinate,
@@ -26,22 +27,36 @@ const useForm = (postTarget) => {
       created_at: Date.now() / 1000.0,
       url: REACT_APP_SERVER_URL === 'http://localhost:5000' ? 'http://localhost.com' : REACT_APP_SERVER_URL,
       source: 'ilmoitus',
-      phone: values.phone,
-      email: values.email,
+      phone: values.phone || '',
+      email: values.email || '',
       miscText: values.misctext || '',
     });
   };
 
   const validate = (event, name, value) => {
     switch (name) {
-      case 'divername':
+      case 'targetname':
 
         if (
-          !(/(?!.*?\s{2})[ A-Za-zäöåÅÄÖ]{7,20}/).test(value)
+          !(/(?!.*?\s{2})[ A-Za-zäöåÅÄÖ]{4,30}/).test(value)
         ) {
           setErrors({
             ...errors,
-            divername: 'Tulee olla 7-20 merkkiä pitkä ja sisältää vain kirjaimia ja välilyöntejä',
+            divername: 'Tulee olla 4-30 merkkiä pitkä ja sisältää vain kirjaimia ja välilyöntejä',
+          });
+        } else {
+          const newObj = omit(errors, 'divername');
+          setErrors(newObj);
+        }
+        break;
+      case 'divername':
+
+        if (
+          !(/(?!.*?\s{2})[ A-Za-zäöåÅÄÖ]{4,30}/).test(value)
+        ) {
+          setErrors({
+            ...errors,
+            divername: 'Tulee olla 4-30 merkkiä pitkä ja sisältää vain kirjaimia ja välilyöntejä',
           });
         } else {
           const newObj = omit(errors, 'divername');
@@ -202,7 +217,7 @@ const useForm = (postTarget) => {
       return;
     }
 
-    if (Object.keys(errors).length === 0 && Object.keys(requiredValues).length === 7) {
+    if (Object.keys(errors).length === 0 && Object.keys(requiredValues).length === 8) {
       callback(event);
       setMessage('Lomake lähetetty!');
       setTimeout(() => {


### PR DESCRIPTION
Lisäsin hylyn ilmoittamislomakkeeseen sukeltajan nimen ja refaktoroin testit samalla. Kun tämä  (ja https://github.com/Sukellusilmoitus/backend/pull/23 ) on mergetty niin back osaa tallentaa hylkyilmoituksesta myös ilmoittajan tiedot eikä pelkkää hylkyä kuten tähän asti.