### PR TITLE
coordinate fix -coords reverse removed

### DIFF
--- a/src/components/TargetPage/TargetLocationMap.jsx
+++ b/src/components/TargetPage/TargetLocationMap.jsx
@@ -4,7 +4,7 @@ import {
 } from 'react-leaflet';
 
 function TargetLocationMap({ target }) {
-  const { coordinates } = target.geometry;
+  const coordinates = [target.geometry.coordinates[1], target.geometry.coordinates[0]];
   return (
     <MapContainer center={coordinates} zoom={8} style={{ height: '250px', width: '100%' }}>
       <LayersControl position="topright">

--- a/src/components/TargetPage/index.jsx
+++ b/src/components/TargetPage/index.jsx
@@ -35,9 +35,6 @@ function Target({ target }) {
     );
   }
 
-  // this flips the coordinates because map takes them in order y, x
-  target.geometry.coordinates.reverse();
-
   return (
     <TargetPage
       target={target}

--- a/src/hooks/useNewNotificationForm.jsx
+++ b/src/hooks/useNewNotificationForm.jsx
@@ -133,7 +133,6 @@ const useNotificationForm = (props) => {
           const newObj = omit(errors, 'xcoordinate');
           setErrors(newObj);
           setNewMapX(value);
-          console.log('juuri astetettu uusi X: ', newMapX);
           setCenter([newMapY, newMapX]);
         }
         break;

--- a/src/hooks/useNewNotificationForm.jsx
+++ b/src/hooks/useNewNotificationForm.jsx
@@ -22,7 +22,7 @@ const useNotificationForm = (props) => {
   const [locationCorrect, setLocationCorrect] = useState(true);
   const [newMapX, setNewMapX] = useState(targetXcoordinate);
   const [newMapY, setNewMapY] = useState(targetYcoordinate);
-  const [center, setCenter] = useState([newMapX, newMapY]);
+  const [center, setCenter] = useState([newMapY, newMapX]);
 
   const callback = (event) => {
     event.preventDefault();
@@ -43,8 +43,8 @@ const useNotificationForm = (props) => {
   };
 
   useEffect(() => {
-    setCenter([newMapX, newMapY]);
-  }, [newMapX, newMapY]);
+    setCenter([newMapY, newMapX]);
+  }, [newMapY, newMapX]);
 
   const validate = (event, name, value) => {
     switch (name) {
@@ -133,7 +133,8 @@ const useNotificationForm = (props) => {
           const newObj = omit(errors, 'xcoordinate');
           setErrors(newObj);
           setNewMapX(value);
-          setCenter([newMapX, newMapY]);
+          console.log('juuri astetettu uusi X: ', newMapX);
+          setCenter([newMapY, newMapX]);
         }
         break;
       case 'ycoordinate':
@@ -149,7 +150,7 @@ const useNotificationForm = (props) => {
           const newObj = omit(errors, 'ycoordinate');
           setErrors(newObj);
           setNewMapY(value);
-          setCenter([newMapX, newMapY]);
+          setCenter([newMapY, newMapX]);
         }
         break;
       case 'coordinateinfo':


### PR DESCRIPTION
Koordinaattisekoilu johtui reactin komponenttien tiheästä päivittelystä. Sen takia koordinaattien kääntämistoiminto aktivoitui liian usein. Kääntämistoiminto on nyt poistettu.