### PR TITLE
New target url and user page phone number add

### DIFF
--- a/src/components/UserPage/UserInfo.jsx
+++ b/src/components/UserPage/UserInfo.jsx
@@ -16,6 +16,10 @@ function UserInfo({ user }) {
             <td>Email</td>
             <td>{user.email}</td>
           </tr>
+          <tr>
+            <td>Puhelinnumero</td>
+            <td>{user.phone}</td>
+          </tr>
         </tbody>
       </Table>
     </Container>

--- a/src/components/UserPage/UserInfo.test.js
+++ b/src/components/UserPage/UserInfo.test.js
@@ -19,5 +19,6 @@ describe('user info table tests', () => {
     const tableRows = screen.getAllByRole('row')
     expect(tableRows[0]).toHaveTextContent(/^Käyttäjänimidoer$/)
     expect(tableRows[1]).toHaveTextContent(/^Emaildoer@test.com$/)
+    expect(tableRows[2]).toHaveTextContent(/^Puhelinnumero000001111$/)
   })
 })

--- a/src/hooks/useNewTargetForm.jsx
+++ b/src/hooks/useNewTargetForm.jsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { omit } from 'lodash';
 import targets from '../services/targets';
-import REACT_APP_SERVER_URL from '../util/config';
 
 const useForm = (postTarget) => {
   const [requiredValues, setRequiredValues] = useState({});
@@ -13,6 +12,9 @@ const useForm = (postTarget) => {
     event.preventDefault();
     // Try to generate target id until free one is found
     const targetID = await targets.generateUniqueID();
+    const baseUrl = 'https://sukellusilmo-front-staging.herokuapp.com';
+    const targetUrl = `${baseUrl}/hylyt/${targetID}`;
+
     postTarget({
       id: targetID,
       targetname: requiredValues.targetname,
@@ -26,7 +28,7 @@ const useForm = (postTarget) => {
       is_ancient: false,
       is_pending: true,
       created_at: Date.now() / 1000.0,
-      url: REACT_APP_SERVER_URL === 'http://localhost:5000' ? 'http://localhost.com' : REACT_APP_SERVER_URL,
+      url: targetUrl,
       source: 'ilmoitus',
       phone: values.phone || '',
       email: values.email || '',


### PR DESCRIPTION
Uudelle hylylle url:iksi herokun frontin hylkyosoite backin osoitteen sijaan. Koetin laittaa .env:iin mutta ei onnistunut vaan siellä oleva server_url meni sekaisin kun lisäsi toisen. Joten on nyt kovakoodattuna.

Käyttäjän tietoihin lisätty puhelinnumero, oli unohtunut aiemmin.