### PR TITLE
Date fixes

### DIFF
--- a/src/components/NewTargetForm.jsx
+++ b/src/components/NewTargetForm.jsx
@@ -61,11 +61,11 @@ function NewTargetForm(props) {
       </Helmet>
       <PageTitle text="Tee ilmoitus uudesta kohteesta" />
       <Submitmessage message={message} />
-      <p>
+      <>
         Suosittelemme yksityiskohtaisemman ilmoituksen tekemistä Museoviraston
         {' '}
         <a href="https://www.kyppi.fi/ilppari" target="_blank" rel="noopener noreferrer">sivuilla.</a>
-      </p>
+      </>
       <h5>Kohteen tiedot</h5>
       <Form
         onSubmit={handleSubmit}
@@ -91,7 +91,7 @@ function NewTargetForm(props) {
         </Form.Group>
         <br />
         {loggeduser !== null && (
-        <p>
+        <>
           {' '}
           <Form.Group>
             <Form.Label>Ilmoittajan nimi:</Form.Label>
@@ -128,10 +128,10 @@ function NewTargetForm(props) {
               readOnly
             />
           </Form.Group>
-        </p>
+        </>
         )}
         {loggeduser === null && (
-        <p>
+        <>
           {' '}
           <Form.Group>
             <Form.Label>Ilmoittajan nimi:</Form.Label>
@@ -185,7 +185,7 @@ function NewTargetForm(props) {
               </Form.Group>
             </Col>
           </Row>
-        </p>
+        </>
         )}
         <br />
         <Row>

--- a/src/components/NotificationForm.jsx
+++ b/src/components/NotificationForm.jsx
@@ -88,7 +88,7 @@ function NewNotificationForm(props) {
         id="newtargetform"
       >
         {loggeduser !== null && (
-        <p>
+        <>
           {' '}
           <Form.Group>
             <Form.Label>Sukeltajan etu- ja sukunimi:</Form.Label>
@@ -125,10 +125,10 @@ function NewNotificationForm(props) {
               readOnly
             />
           </Form.Group>
-        </p>
+        </>
         )}
         {loggeduser === null && (
-        <p>
+        <>
           {' '}
           <Form.Group>
             <Form.Label>Sukeltajan etu- ja sukunimi:</Form.Label>
@@ -183,7 +183,7 @@ function NewNotificationForm(props) {
               { errors.email }
             </Form.Control.Feedback>
           </Form.Group>
-        </p>
+        </>
         )}
         <Form.Group>
           <br />
@@ -266,7 +266,7 @@ function NewNotificationForm(props) {
             onChange={(c) => { handleCoordinateChangeClick(c.target.value); }}
           />
           {coordinateRadio === 'no' && (
-          <p>
+          <>
             {' '}
             <Form.Label>Uusi pituuspiiri desimaaliasteina:</Form.Label>
             <Form.Control
@@ -331,7 +331,7 @@ function NewNotificationForm(props) {
             <Form.Control.Feedback type="invalid">
               { errors.coordinateinfo }
             </Form.Control.Feedback>
-          </p>
+          </>
           )}
         </Form.Group>
         <Form.Group>
@@ -354,7 +354,7 @@ function NewNotificationForm(props) {
             onChange={(c) => { handleChangeRadio(c.target.value); }}
           />
           {changeRadio === 'yes' && (
-          <p>
+          <>
             {' '}
             <Form.Label>Kuvaile muutoksia:</Form.Label>
             <Form.Control
@@ -372,7 +372,7 @@ function NewNotificationForm(props) {
             <Form.Control.Feedback type="invalid">
               { errors.changeText }
             </Form.Control.Feedback>
-          </p>
+          </>
           )}
         </Form.Group>
         <Form.Group>

--- a/src/components/TargetPage/DiveHistory.jsx
+++ b/src/components/TargetPage/DiveHistory.jsx
@@ -26,7 +26,7 @@ function DiveHistory({ diveList }) {
         {diveList.length > 0
           ? diveList.map((dive) => (
             <div key={dive.id} data-testid={dive.id}>
-              <strong>{dayjs(dive.created_at).format('DD.MM.YYYY')}</strong>
+              <strong>{dayjs(dive.divedate).format('DD.MM.YYYY')}</strong>
               <br />
               Sukeltaja:
               {' '}
@@ -35,6 +35,8 @@ function DiveHistory({ diveList }) {
               Muutokset:
               {' '}
               <i>{dive.change_text || 'ei muutoksia'}</i>
+              <br />
+              <br />
             </div>
           ))
           : <div>Ei rekisteröityjä sukelluksia</div>}

--- a/src/components/TargetPage/DiveHistory.test.js
+++ b/src/components/TargetPage/DiveHistory.test.js
@@ -28,6 +28,7 @@ const mockDiveList = [
       }
     },
     created_at: '20200202T10:00:00',
+    divedate: '20200201T10:00:00',
     location_correction: true,
     new_x_coordinates: '',
     new_y_coordinates: '',
@@ -60,6 +61,7 @@ const mockDiveList = [
       }
     },
     created_at: '20200202T10:00:00',
+    divedate: '20200201T10:00:00',
     location_correction: true,
     new_x_coordinates: '',
     new_y_coordinates: '',
@@ -77,7 +79,7 @@ describe('dive history list tests', () => {
     expect(heading).toHaveTextContent('Sukellushistoria')
 
     const diveData = screen.getByTestId('123')
-    expect(diveData).toHaveTextContent('02.02.2020')
+    expect(diveData).toHaveTextContent('01.02.2020')
     expect(diveData).toHaveTextContent('Sukeltaja: test diver')
     expect(diveData).toHaveTextContent('Muutokset: no changes')
   })

--- a/src/components/UserPage/UserDiveHistory.jsx
+++ b/src/components/UserPage/UserDiveHistory.jsx
@@ -33,7 +33,7 @@ function UserDiveHistory({ dives }) {
         {dives.length > 0
           ? dives.map((dive) => (
             <div key={dive.id} data-testid={dive.id}>
-              <strong>{dayjs(dive.created_at).format('DD.MM.YYYY')}</strong>
+              <strong>{dayjs(dive.divedate).format('DD.MM.YYYY')}</strong>
               <br />
               Kohde:
               {' '}

--- a/src/components/UserPage/UserDiveHistory.test.js
+++ b/src/components/UserPage/UserDiveHistory.test.js
@@ -28,6 +28,7 @@ const mockDiveList = [
       }
     },
     created_at: '20200202T10:00:00',
+    divedate: '20200130T10:00:00',
     location_correction: true,
     new_x_coordinates: '',
     new_y_coordinates: '',
@@ -60,6 +61,7 @@ const mockDiveList = [
       }
     },
     created_at: '20200202T10:00:00',
+    divedate: '20200130T10:00:00',
     location_correction: true,
     new_x_coordinates: '',
     new_y_coordinates: '',
@@ -77,7 +79,7 @@ describe('user dive history list tests', () => {
     expect(heading).toHaveTextContent('Sukellushistoria')
 
     const diveData = screen.getByTestId('1231')
-    expect(diveData).toHaveTextContent('02.02.2020')
+    expect(diveData).toHaveTextContent('30.01.2020')
     expect(diveData).toHaveTextContent('Hylyn muutokset: no changes')
   })
 


### PR DESCRIPTION
Sukelluspäivämäärät näkyviin sukellusilmoituksiin ja testien päivitys.

Samalla muutettu formien p-elementit tyhjiksi ettei jest-testit herjaa niistä.

Vaatii backin PR:n https://github.com/Sukellusilmoitus/backend/pull/58