### PR TITLE
Notify user that the wreck doesnt immediately show on the site

### DIFF
--- a/src/components/NewTargetForm.jsx
+++ b/src/components/NewTargetForm.jsx
@@ -70,8 +70,10 @@ function NewTargetForm(props) {
         Suosittelemme yksityiskohtaisemman ilmoituksen tekemistä Museoviraston
         {' '}
         <a href="https://www.kyppi.fi/ilppari" target="_blank" rel="noopener noreferrer">sivuilla.</a>
+        {' '}
+        Hylkyilmoitus jää odottamaan ylläpitäjän hyväksyntää,
+        joten se ei näy välittömästi tietokannassa.
       </>
-      <strong>Kohteen tiedot</strong>
       <Form
         onSubmit={handleSubmit}
         data-testid="testform"


### PR DESCRIPTION
- Lisätty teksti "Hylkyilmoitus jää odottamaan ylläpitäjän hyväksyntää, joten se ei näy välittömästi tietokannassa."
- Poistettu "kohteen tiedot" -teksti